### PR TITLE
[autocomplete] - added basic autocomplete example

### DIFF
--- a/src/Home.js
+++ b/src/Home.js
@@ -58,6 +58,9 @@ const Home = () => (
       <ListItem>
         <StyledLink to={`${defaultPath}searchbox`}>SearchBox</StyledLink>
       </ListItem>
+      <ListItem>
+        <StyledLink to={`${defaultPath}autocomplete`}>Autocomplete</StyledLink>
+      </ListItem>
     </List>
   </Wrapper>
 );

--- a/src/components/AutoComplete.js
+++ b/src/components/AutoComplete.js
@@ -24,7 +24,7 @@ class AutoComplete extends Component {
     };
     this.autoComplete = new mapApi.places.Autocomplete(
       this.searchInput,
-      options
+      options,
     );
     this.autoComplete.addListener('place_changed', this.onPlaceChanged);
     this.autoComplete.bindTo('bounds', map);
@@ -57,7 +57,7 @@ class AutoComplete extends Component {
     return (
       <Wrapper>
         <input
-          ref={ref => {
+          ref={(ref) => {
             this.searchInput = ref;
           }}
           type="text"

--- a/src/components/AutoComplete.js
+++ b/src/components/AutoComplete.js
@@ -1,0 +1,72 @@
+import React, { Component } from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 20px;
+`;
+
+class AutoComplete extends Component {
+  constructor(props) {
+    super(props);
+    this.clearSearchBox = this.clearSearchBox.bind(this);
+  }
+
+  componentDidMount({ map, mapApi } = this.props) {
+    const options = {
+      // restrict your search to a specific type of result
+      // types: ['geocode', 'address', 'establishment', '(regions)', '(cities)'],
+      // restrict your search to a specific country, or an array of countries
+      // componentRestrictions: { country: ['gb', 'us'] },
+    };
+    this.autoComplete = new mapApi.places.Autocomplete(
+      this.searchInput,
+      options
+    );
+    this.autoComplete.addListener('place_changed', this.onPlaceChanged);
+    this.autoComplete.bindTo('bounds', map);
+  }
+
+  componentWillUnmount({ mapApi } = this.props) {
+    mapApi.event.clearInstanceListeners(this.searchInput);
+  }
+
+  onPlaceChanged = ({ map, addplace } = this.props) => {
+    const place = this.autoComplete.getPlace();
+
+    if (!place.geometry) return;
+    if (place.geometry.viewport) {
+      map.fitBounds(place.geometry.viewport);
+    } else {
+      map.setCenter(place.geometry.location);
+      map.setZoom(17);
+    }
+
+    addplace(place);
+    this.searchInput.blur();
+  };
+
+  clearSearchBox() {
+    this.searchInput.value = '';
+  }
+
+  render() {
+    return (
+      <Wrapper>
+        <input
+          ref={ref => {
+            this.searchInput = ref;
+          }}
+          type="text"
+          onFocus={this.clearSearchBox}
+          placeholder="Enter a location"
+        />
+      </Wrapper>
+    );
+  }
+}
+
+export default AutoComplete;

--- a/src/examples/Autocomplete.js
+++ b/src/examples/Autocomplete.js
@@ -19,7 +19,7 @@ class Autocomplete extends Component {
       mapApiLoaded: false,
       mapInstance: null,
       mapApi: null,
-      places: []
+      places: [],
     };
   }
 
@@ -27,31 +27,29 @@ class Autocomplete extends Component {
     this.setState({
       mapApiLoaded: true,
       mapInstance: map,
-      mapApi: maps
+      mapApi: maps,
     });
   };
 
-  addPlace = place => {
+  addPlace = (place) => {
     this.setState({ places: [place] });
   };
 
   render() {
-    const { places, mapApiLoaded, mapInstance, mapApi } = this.state;
+    const {
+      places, mapApiLoaded, mapInstance, mapApi,
+    } = this.state;
     return (
       <Fragment>
         {mapApiLoaded && (
-          <AutoComplete
-            map={mapInstance}
-            mapApi={mapApi}
-            addplace={this.addPlace}
-          />
+          <AutoComplete map={mapInstance} mapApi={mapApi} addplace={this.addPlace} />
         )}
         <GoogleMap
           defaultZoom={10}
           defaultCenter={LOS_ANGELES_CENTER}
           bootstrapURLKeys={{
             key: process.env.REACT_APP_MAP_KEY,
-            libraries: ['places', 'geometry']
+            libraries: ['places', 'geometry'],
           }}
           yesIWantToUseGoogleMapApiInternals
           onGoogleApiLoaded={({ map, maps }) => this.apiHasLoaded(map, maps)}

--- a/src/examples/Autocomplete.js
+++ b/src/examples/Autocomplete.js
@@ -1,0 +1,74 @@
+import React, { Component, Fragment } from 'react';
+import isEmpty from 'lodash.isempty';
+
+// components:
+import Marker from '../components/Marker';
+
+// examples:
+import GoogleMap from '../components/GoogleMap';
+import AutoComplete from '../components/AutoComplete';
+
+// consts
+import LOS_ANGELES_CENTER from '../const/la_center';
+
+class Autocomplete extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      mapApiLoaded: false,
+      mapInstance: null,
+      mapApi: null,
+      places: []
+    };
+  }
+
+  apiHasLoaded = (map, maps) => {
+    this.setState({
+      mapApiLoaded: true,
+      mapInstance: map,
+      mapApi: maps
+    });
+  };
+
+  addPlace = place => {
+    this.setState({ places: [place] });
+  };
+
+  render() {
+    const { places, mapApiLoaded, mapInstance, mapApi } = this.state;
+    return (
+      <Fragment>
+        {mapApiLoaded && (
+          <AutoComplete
+            map={mapInstance}
+            mapApi={mapApi}
+            addplace={this.addPlace}
+          />
+        )}
+        <GoogleMap
+          defaultZoom={10}
+          defaultCenter={LOS_ANGELES_CENTER}
+          bootstrapURLKeys={{
+            key: process.env.REACT_APP_MAP_KEY,
+            libraries: ['places', 'geometry']
+          }}
+          yesIWantToUseGoogleMapApiInternals
+          onGoogleApiLoaded={({ map, maps }) => this.apiHasLoaded(map, maps)}
+        >
+          {!isEmpty(places) &&
+            places.map(place => (
+              <Marker
+                key={place.id}
+                text={place.name}
+                lat={place.geometry.location.lat()}
+                lng={place.geometry.location.lng()}
+              />
+            ))}
+        </GoogleMap>
+      </Fragment>
+    );
+  }
+}
+
+export default Autocomplete;

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {
-  Route,
-  Switch,
-  Redirect,
-  BrowserRouter as Router
-} from 'react-router-dom';
+import { Route, Switch, Redirect, BrowserRouter as Router } from 'react-router-dom';
 
 // examples:
 import Home from './Home';
@@ -37,7 +32,7 @@ ReactDOM.render(
       </Switch>
     </App>
   </Router>,
-  document.getElementById('root')
+  document.getElementById('root'),
 );
 
 registerServiceWorker();

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Route, Switch, Redirect, BrowserRouter as Router } from 'react-router-dom';
+import {
+  Route,
+  Switch,
+  Redirect,
+  BrowserRouter as Router
+} from 'react-router-dom';
 
 // examples:
 import Home from './Home';
 import Main from './examples/Main';
 import SearchBox from './examples/Searchbox';
+import Autocomplete from './examples/Autocomplete';
 
 // styles
 import './index.css';
@@ -26,11 +32,12 @@ ReactDOM.render(
         {/* New examples here */}
         <Route path={`${defaultPath}default`} component={Main} />
         <Route path={`${defaultPath}searchbox`} component={SearchBox} />
+        <Route path={`${defaultPath}autocomplete`} component={Autocomplete} />
         <Redirect exact from="*" to={defaultPath} />
       </Switch>
     </App>
   </Router>,
-  document.getElementById('root'),
+  document.getElementById('root')
 );
 
 registerServiceWorker();


### PR DESCRIPTION
Added basic autocomplete functionality - main differences are [sending the data in an array](https://github.com/google-map-react/google-map-react-examples/commit/92bcd282e47576215b0f0b38c49ab421a7f568ab#diff-67f4af93f877fde83689d11e849e06baR35), so we can still `.map` it, and the comments [here](https://github.com/google-map-react/google-map-react-examples/commit/92bcd282e47576215b0f0b38c49ab421a7f568ab#diff-9d6c0b5044fe5931ca5539d8b6c57068R20)

We can add some instructions at the top of the demo page in the design PR to make what the comments do clearer

Also added a function to clear the search input on focus, which I'd removed by accident in the searchbox PR