### PR TITLE
Add Marker and Info Window examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 - [React-router](https://reacttraining.com/react-router/) for routing
 - [Styled components](https://www.styled-components.com/) for styling our components
 
-## Examples:
+## Examples
 
-- [Main](https://google-map-react.github.io/google-map-react-examples/default), [source](https://github.com/google-map-react/google-map-react-examples/blob/master/src/examples/Main.js)
-- [Searchbox](https://google-map-react.github.io/google-map-react-examples/searchbox), [source](https://github.com/google-map-react/google-map-react-examples/blob/master/src/examples/Searchbox.js)
-- [Autocomplete](https://google-map-react.github.io/google-map-react-examples/autocomplete), [source](https://github.com/google-map-react/google-map-react-examples/blob/master/src/examples/Searchbox.js)
+- [Main](https://google-map-react.github.io/google-map-react-examples/default) ([source](https://github.com/google-map-react/google-map-react-examples/blob/master/src/examples/Main.js))
+- [Searchbox](https://google-map-react.github.io/google-map-react-examples/searchbox) ([source](https://github.com/google-map-react/google-map-react-examples/blob/master/src/examples/Searchbox.js))
+- [Autocomplete](https://google-map-react.github.io/google-map-react-examples/autocomplete) ([source](https://github.com/google-map-react/google-map-react-examples/blob/master/src/examples/Searchbox.js))
+- [Marker and Info Window (React Component)](https://google-map-react.github.io/google-map-react-examples/marker-info-window) ([source](https://github.com/google-map-react/google-map-react-examples/blob/master/src/examples/MarkerInfoWindow.js))
+- [Marker and Info Window (Google Maps API Object)](https://google-map-react.github.io/google-map-react-examples/marker-info-window-gmaps-obj) ([source](https://github.com/google-map-react/google-map-react-examples/blob/master/src/examples/MarkerInfoWindowGmapsObj.js))
 
 ## Getting started
 

--- a/src/Home.js
+++ b/src/Home.js
@@ -64,6 +64,12 @@ const Home = () => (
       <ListItem>
         <StyledLink to={`${defaultPath}autocomplete`}>Autocomplete</StyledLink>
       </ListItem>
+      <ListItem>
+        <StyledLink to={`${defaultPath}marker-info-window`}>Marker and Info Window (React Component)</StyledLink>
+      </ListItem>
+      <ListItem>
+        <StyledLink to={`${defaultPath}marker-info-window-gmaps-obj`}>Marker and Info Window (Google Maps API Object)</StyledLink>
+      </ListItem>
     </List>
   </Wrapper>
 );

--- a/src/examples/MarkerInfoWindow.js
+++ b/src/examples/MarkerInfoWindow.js
@@ -95,10 +95,9 @@ class MarkerInfoWindow extends Component {
   // onChildClick callback can take two arguments: key and childProps
   onChildClickCallback = (key) => {
     this.setState((state) => {
-      const prevState = state;
-      const index = prevState.places.findIndex(e => e.id === key);
-      prevState.places[index].show = !prevState.places[index].show;
-      return { places: prevState.places };
+      const index = state.places.findIndex(e => e.id === key);
+      state.places[index].show = !state.places[index].show; // eslint-disable-line no-param-reassign
+      return { places: state.places };
     });
   };
 

--- a/src/examples/MarkerInfoWindow.js
+++ b/src/examples/MarkerInfoWindow.js
@@ -1,0 +1,130 @@
+import React, { Component, Fragment } from 'react';
+import isEmpty from 'lodash.isempty';
+
+// examples:
+import GoogleMap from '../components/GoogleMap';
+
+// consts: [34.0522, -118.2437]
+import LOS_ANGELES_CENTER from '../const/la_center';
+
+// InfoWindow component
+const InfoWindow = props => {
+  const { place } = props;
+  const infoWindowStyle = {
+    position: "relative",
+    bottom: 150,
+    left: "-45px",
+    width: 220,
+    backgroundColor: "white",
+    boxShadow: "0 2px 7px 1px rgba(0, 0, 0, 0.3)",
+    padding: 10,
+    fontSize: 14,
+    zIndex: 100,
+  };
+
+  return (
+    <div style={infoWindowStyle}>
+      <div style={{fontSize: 16}}>
+        {place.name}
+      </div>
+      <div style={{fontSize: 14}}>
+        <span style={{color: "grey"}}>
+        {place.rating}{" "}
+        </span>
+        <span style={{color: "orange"}}>
+          {String.fromCharCode(9733).repeat(Math.floor(place.rating))}
+        </span>
+        <span style={{color: "lightgrey"}}>
+          {String.fromCharCode(9733).repeat(5 - Math.floor(place.rating))}
+        </span>
+      </div>
+      <div style={{fontSize: 14, color: "grey"}}>
+        {place.types[0]}
+      </div>
+      <div style={{fontSize: 14, color: "grey"}}>
+        {"$".repeat(place.price_level)}
+      </div>
+      <div style={{fontSize: 14, color: "green"}}>
+        {place.opening_hours.open_now ? "Open" : "Closed"}
+      </div>
+    </div>
+  );
+};
+
+// Marker component
+const Marker = props => {
+  const markerStyle = {
+    border: "1px solid white",
+    borderRadius: "50%",
+    height: 10,
+    width: 10,
+    backgroundColor: props.show ? "red" : "blue",
+    cursor: "pointer",
+    zIndex: 10,
+  };
+
+  return (
+    <Fragment>
+      <div style={markerStyle} />
+      {props.show && <InfoWindow place={props.place} />}
+    </Fragment>
+  );
+};
+
+class MarkerInfoWindow extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      places: [],
+    };
+  }
+
+  _onChildClick = (key, childProps) => {
+    this.setState(state => {
+      const index = state.places.findIndex(e => e.id === key);
+      state.places[index].show = !state.places[index].show;
+      return {places: state.places};
+    });
+  };
+
+  componentDidMount() {
+    fetch('places.json')
+      .then(response => response.json())
+      .then(data => {
+        data.results.forEach(result => {
+          result.show = false;
+        });
+        this.setState({ places: data.results });
+      });
+  }
+
+  render() {
+    const { places } = this.state;
+
+    return (
+      <Fragment>
+        {!isEmpty(places) && (
+          <GoogleMap
+            defaultZoom={10}
+            defaultCenter={LOS_ANGELES_CENTER}
+            bootstrapURLKeys={{key: process.env.REACT_APP_MAP_KEY}}
+            onChildClick={this._onChildClick}
+          >
+            {places.map(place =>
+              <Marker
+                key={place.id}
+                lat={place.geometry.location.lat}
+                lng={place.geometry.location.lng}
+                show={place.show}
+                place={place}
+              />
+            )}
+          </GoogleMap>
+        )}
+      </Fragment>
+    );
+  }
+}
+
+export default MarkerInfoWindow;

--- a/src/examples/MarkerInfoWindow.js
+++ b/src/examples/MarkerInfoWindow.js
@@ -1,4 +1,5 @@
 import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
 import isEmpty from 'lodash.isempty';
 
 // examples:
@@ -8,15 +9,15 @@ import GoogleMap from '../components/GoogleMap';
 import LOS_ANGELES_CENTER from '../const/la_center';
 
 // InfoWindow component
-const InfoWindow = props => {
+const InfoWindow = (props) => {
   const { place } = props;
   const infoWindowStyle = {
-    position: "relative",
+    position: 'relative',
     bottom: 150,
-    left: "-45px",
+    left: '-45px',
     width: 220,
-    backgroundColor: "white",
-    boxShadow: "0 2px 7px 1px rgba(0, 0, 0, 0.3)",
+    backgroundColor: 'white',
+    boxShadow: '0 2px 7px 1px rgba(0, 0, 0, 0.3)',
     padding: 10,
     fontSize: 14,
     zIndex: 100,
@@ -24,42 +25,42 @@ const InfoWindow = props => {
 
   return (
     <div style={infoWindowStyle}>
-      <div style={{fontSize: 16}}>
+      <div style={{ fontSize: 16 }}>
         {place.name}
       </div>
-      <div style={{fontSize: 14}}>
-        <span style={{color: "grey"}}>
-        {place.rating}{" "}
+      <div style={{ fontSize: 14 }}>
+        <span style={{ color: 'grey' }}>
+          {place.rating}{' '}
         </span>
-        <span style={{color: "orange"}}>
+        <span style={{ color: 'orange' }}>
           {String.fromCharCode(9733).repeat(Math.floor(place.rating))}
         </span>
-        <span style={{color: "lightgrey"}}>
+        <span style={{ color: 'lightgrey' }}>
           {String.fromCharCode(9733).repeat(5 - Math.floor(place.rating))}
         </span>
       </div>
-      <div style={{fontSize: 14, color: "grey"}}>
+      <div style={{ fontSize: 14, color: 'grey' }}>
         {place.types[0]}
       </div>
-      <div style={{fontSize: 14, color: "grey"}}>
-        {"$".repeat(place.price_level)}
+      <div style={{ fontSize: 14, color: 'grey' }}>
+        {'$'.repeat(place.price_level)}
       </div>
-      <div style={{fontSize: 14, color: "green"}}>
-        {place.opening_hours.open_now ? "Open" : "Closed"}
+      <div style={{ fontSize: 14, color: 'green' }}>
+        {place.opening_hours.open_now ? 'Open' : 'Closed'}
       </div>
     </div>
   );
 };
 
 // Marker component
-const Marker = props => {
+const Marker = (props) => {
   const markerStyle = {
-    border: "1px solid white",
-    borderRadius: "50%",
+    border: '1px solid white',
+    borderRadius: '50%',
     height: 10,
     width: 10,
-    backgroundColor: props.show ? "red" : "blue",
-    cursor: "pointer",
+    backgroundColor: props.show ? 'red' : 'blue',
+    cursor: 'pointer',
     zIndex: 10,
   };
 
@@ -80,24 +81,26 @@ class MarkerInfoWindow extends Component {
     };
   }
 
-  _onChildClick = (key, childProps) => {
-    this.setState(state => {
-      const index = state.places.findIndex(e => e.id === key);
-      state.places[index].show = !state.places[index].show;
-      return {places: state.places};
-    });
-  };
-
   componentDidMount() {
     fetch('places.json')
       .then(response => response.json())
-      .then(data => {
-        data.results.forEach(result => {
-          result.show = false;
+      .then((data) => {
+        data.results.forEach((result) => {
+          result.show = false; // eslint-disable-line no-param-reassign
         });
         this.setState({ places: data.results });
       });
   }
+
+  // onChildClick callback can take two arguments: key and childProps
+  onChildClickCallback = (key) => {
+    this.setState((state) => {
+      const prevState = state;
+      const index = prevState.places.findIndex(e => e.id === key);
+      prevState.places[index].show = !prevState.places[index].show;
+      return { places: prevState.places };
+    });
+  };
 
   render() {
     const { places } = this.state;
@@ -108,23 +111,45 @@ class MarkerInfoWindow extends Component {
           <GoogleMap
             defaultZoom={10}
             defaultCenter={LOS_ANGELES_CENTER}
-            bootstrapURLKeys={{key: process.env.REACT_APP_MAP_KEY}}
-            onChildClick={this._onChildClick}
+            bootstrapURLKeys={{ key: process.env.REACT_APP_MAP_KEY }}
+            onChildClick={this.onChildClickCallback}
           >
             {places.map(place =>
-              <Marker
+              (<Marker
                 key={place.id}
                 lat={place.geometry.location.lat}
                 lng={place.geometry.location.lng}
                 show={place.show}
                 place={place}
-              />
-            )}
+              />))}
           </GoogleMap>
         )}
       </Fragment>
     );
   }
 }
+
+InfoWindow.propTypes = {
+  place: PropTypes.shape({
+    name: PropTypes.string,
+    formatted_address: PropTypes.string,
+    rating: PropTypes.number,
+    types: PropTypes.array,
+    price_level: PropTypes.number,
+    opening_hours: PropTypes.object,
+  }).isRequired,
+};
+
+Marker.propTypes = {
+  show: PropTypes.bool.isRequired,
+  place: PropTypes.shape({
+    name: PropTypes.string,
+    formatted_address: PropTypes.string,
+    rating: PropTypes.number,
+    types: PropTypes.array,
+    price_level: PropTypes.number,
+    opening_hours: PropTypes.object,
+  }).isRequired,
+};
 
 export default MarkerInfoWindow;

--- a/src/examples/MarkerInfoWindowGmapsObj.js
+++ b/src/examples/MarkerInfoWindowGmapsObj.js
@@ -7,8 +7,7 @@ import GoogleMap from '../components/GoogleMap';
 // consts: [34.0522, -118.2437]
 import LOS_ANGELES_CENTER from '../const/la_center';
 
-const getInfoWindowString = place => {
-  return `
+const getInfoWindowString = place => `
     <div>
       <div style="font-size: 16px;">
         ${place.name}
@@ -23,26 +22,25 @@ const getInfoWindowString = place => {
         ${place.types[0]}
       </div>
       <div style="font-size: 14px; color: grey;">
-        ${"$".repeat(place.price_level)}
+        ${'$'.repeat(place.price_level)}
       </div>
       <div style="font-size: 14px; color: green;">
-        ${place.opening_hours.open_now ? "Open" : "Closed"}
+        ${place.opening_hours.open_now ? 'Open' : 'Closed'}
       </div>
     </div>`;
-};
 
 // Refer to https://github.com/google-map-react/google-map-react#use-google-maps-api
 const handleApiLoaded = (map, maps, places) => {
-  var markers = [];
-  var infowindows = [];
+  const markers = [];
+  const infowindows = [];
 
-  places.forEach(place => {
+  places.forEach((place) => {
     markers.push(new maps.Marker({
       position: {
         lat: place.geometry.location.lat,
         lng: place.geometry.location.lng,
       },
-      map: map,
+      map,
     }));
 
     infowindows.push(new maps.InfoWindow({
@@ -51,7 +49,7 @@ const handleApiLoaded = (map, maps, places) => {
   });
 
   markers.forEach((marker, i) => {
-    marker.addListener("click", () => {
+    marker.addListener('click', () => {
       infowindows[i].open(map, marker);
     });
   });
@@ -69,9 +67,9 @@ class MarkerInfoWindowGmapsObj extends Component {
   componentDidMount() {
     fetch('places.json')
       .then(response => response.json())
-      .then(data => {
-        data.results.forEach(result => {
-          result.show = false;
+      .then((data) => {
+        data.results.forEach((result) => {
+          result.show = false; // eslint-disable-line no-param-reassign
         });
         this.setState({ places: data.results });
       });
@@ -86,9 +84,9 @@ class MarkerInfoWindowGmapsObj extends Component {
           <GoogleMap
             defaultZoom={10}
             defaultCenter={LOS_ANGELES_CENTER}
-            bootstrapURLKeys={{key: process.env.REACT_APP_MAP_KEY}}
+            bootstrapURLKeys={{ key: process.env.REACT_APP_MAP_KEY }}
             yesIWantToUseGoogleMapApiInternals
-            onGoogleApiLoaded={({map, maps}) => handleApiLoaded(map, maps, places)}
+            onGoogleApiLoaded={({ map, maps }) => handleApiLoaded(map, maps, places)}
           />
         )}
       </Fragment>

--- a/src/examples/MarkerInfoWindowGmapsObj.js
+++ b/src/examples/MarkerInfoWindowGmapsObj.js
@@ -1,0 +1,99 @@
+import React, { Component, Fragment } from 'react';
+import isEmpty from 'lodash.isempty';
+
+// examples:
+import GoogleMap from '../components/GoogleMap';
+
+// consts: [34.0522, -118.2437]
+import LOS_ANGELES_CENTER from '../const/la_center';
+
+const getInfoWindowString = place => {
+  return `
+    <div>
+      <div style="font-size: 16px;">
+        ${place.name}
+      </div>
+      <div style="font-size: 14px;">
+        <span style="color: grey;">
+        ${place.rating}
+        </span>
+        <span style="color: orange;">${String.fromCharCode(9733).repeat(Math.floor(place.rating))}</span><span style="color: lightgrey;">${String.fromCharCode(9733).repeat(5 - Math.floor(place.rating))}</span>
+      </div>
+      <div style="font-size: 14px; color: grey;">
+        ${place.types[0]}
+      </div>
+      <div style="font-size: 14px; color: grey;">
+        ${"$".repeat(place.price_level)}
+      </div>
+      <div style="font-size: 14px; color: green;">
+        ${place.opening_hours.open_now ? "Open" : "Closed"}
+      </div>
+    </div>`;
+};
+
+// Refer to https://github.com/google-map-react/google-map-react#use-google-maps-api
+const handleApiLoaded = (map, maps, places) => {
+  var markers = [];
+  var infowindows = [];
+
+  places.forEach(place => {
+    markers.push(new maps.Marker({
+      position: {
+        lat: place.geometry.location.lat,
+        lng: place.geometry.location.lng,
+      },
+      map: map,
+    }));
+
+    infowindows.push(new maps.InfoWindow({
+      content: getInfoWindowString(place),
+    }));
+  });
+
+  markers.forEach((marker, i) => {
+    marker.addListener("click", () => {
+      infowindows[i].open(map, marker);
+    });
+  });
+};
+
+class MarkerInfoWindowGmapsObj extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      places: [],
+    };
+  }
+
+  componentDidMount() {
+    fetch('places.json')
+      .then(response => response.json())
+      .then(data => {
+        data.results.forEach(result => {
+          result.show = false;
+        });
+        this.setState({ places: data.results });
+      });
+  }
+
+  render() {
+    const { places } = this.state;
+
+    return (
+      <Fragment>
+        {!isEmpty(places) && (
+          <GoogleMap
+            defaultZoom={10}
+            defaultCenter={LOS_ANGELES_CENTER}
+            bootstrapURLKeys={{key: process.env.REACT_APP_MAP_KEY}}
+            yesIWantToUseGoogleMapApiInternals
+            onGoogleApiLoaded={({map, maps}) => handleApiLoaded(map, maps, places)}
+          />
+        )}
+      </Fragment>
+    );
+  }
+}
+
+export default MarkerInfoWindowGmapsObj;

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,8 @@ import Main from './examples/Main';
 import Heatmap from './examples/Heatmap';
 import SearchBox from './examples/Searchbox';
 import Autocomplete from './examples/Autocomplete';
+import MarkerInfoWindow from './examples/MarkerInfoWindow';
+import MarkerInfoWindowGmapsObj from './examples/MarkerInfoWindowGmapsObj';
 
 // styles
 import './index.css';
@@ -30,6 +32,8 @@ ReactDOM.render(
         <Route path={`${defaultPath}heatmap`} component={Heatmap} />
         <Route path={`${defaultPath}searchbox`} component={SearchBox} />
         <Route path={`${defaultPath}autocomplete`} component={Autocomplete} />
+        <Route path={`${defaultPath}marker-info-window`} component={MarkerInfoWindow} />
+        <Route path={`${defaultPath}marker-info-window-gmaps-obj`} component={MarkerInfoWindowGmapsObj} />
         <Redirect exact from="*" to={defaultPath} />
       </Switch>
     </App>


### PR DESCRIPTION
This PR is made based on https://github.com/google-map-react/google-map-react/issues/704#issuecomment-485999416.

1. adds two examples  to `/src/examples/`
   - Marker and Info Window using React Component
   - Marker and Info Window using Google Maps API Object

2. modifies `/README.md` to
   - include above two examples
   - parenthesize `source` in `Examples:` section
   - remove `:` in `Examples:`